### PR TITLE
feat: embed Calendly inline widget in get_availability tool

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9521,6 +9521,20 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-calendly": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/react-calendly/-/react-calendly-4.4.0.tgz",
+      "integrity": "sha512-kMd8fEby0plL5aCebhjq9aesOJ6YWcmR3Pjs3bufncykrp7b6TryaCnWGoq4xZc/oipyudAVCIRgPVUjUEr8nQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8",
+        "npm": ">=5"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
     "node_modules/react-dom": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
@@ -12129,6 +12143,7 @@
         "@tailwindcss/vite": "^4.2.0",
         "lucide-react": "^0.468.0",
         "react": "^18.3.1",
+        "react-calendly": "^4.4.0",
         "react-dom": "^18.3.1",
         "tailwindcss": "^4.2.0"
       },

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -88,7 +88,8 @@ function createMcpServer() {
                 domain: "https://ask-aneeq-server-production.up.railway.app",
                 csp: {
                   connectDomains: ["https://ask-aneeq-server-production.up.railway.app"],
-                  resourceDomains: ["https://*.oaistatic.com"],
+                  resourceDomains: ["https://*.oaistatic.com", "https://assets.calendly.com"],
+                  frameDomains: ["https://calendly.com"],
                 },
               },
             },

--- a/web/package.json
+++ b/web/package.json
@@ -16,6 +16,7 @@
     "@tailwindcss/vite": "^4.2.0",
     "lucide-react": "^0.468.0",
     "react": "^18.3.1",
+    "react-calendly": "^4.4.0",
     "react-dom": "^18.3.1",
     "tailwindcss": "^4.2.0"
   },

--- a/web/src/components/AvailabilityCard/AvailabilityCard.test.tsx
+++ b/web/src/components/AvailabilityCard/AvailabilityCard.test.tsx
@@ -1,6 +1,12 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { AvailabilityCard } from "./AvailabilityCard";
+
+vi.mock("react-calendly", () => ({
+  InlineWidget: ({ url }: { url: string }) => (
+    <div data-testid="calendly-widget" data-url={url} />
+  ),
+}));
 
 const mockData = {
   bookingUrl: "https://calendly.com/aneeq",
@@ -13,15 +19,17 @@ describe("AvailabilityCard", () => {
     expect(screen.getByText(/Aneeq Hassan/)).toBeInTheDocument();
   });
 
-  it("renders a booking link with correct href", () => {
+  it("renders the Calendly inline widget with correct URL", () => {
     render(<AvailabilityCard data={mockData} />);
-    const link = screen.getByRole("link", { name: /Book a Meeting/i });
-    expect(link).toHaveAttribute("href", "https://calendly.com/aneeq");
+    const widget = screen.getByTestId("calendly-widget");
+    expect(widget).toBeInTheDocument();
+    expect(widget).toHaveAttribute("data-url", "https://calendly.com/aneeq");
   });
 
-  it("opens booking link in new tab", () => {
+  it("renders a fallback link with correct href", () => {
     render(<AvailabilityCard data={mockData} />);
-    const link = screen.getByRole("link", { name: /Book a Meeting/i });
+    const link = screen.getByRole("link", { name: /Can't see it/i });
+    expect(link).toHaveAttribute("href", "https://calendly.com/aneeq");
     expect(link).toHaveAttribute("target", "_blank");
     expect(link).toHaveAttribute("rel", "noopener noreferrer");
   });

--- a/web/src/components/AvailabilityCard/AvailabilityCard.tsx
+++ b/web/src/components/AvailabilityCard/AvailabilityCard.tsx
@@ -1,3 +1,5 @@
+import { InlineWidget } from "react-calendly";
+
 interface Props {
   data: { bookingUrl: string; name: string };
 }
@@ -9,13 +11,14 @@ export function AvailabilityCard({ data }: Props) {
       <p className="text-sm text-secondary mb-4">
         Available for coffee chats, interviews, or collaborations.
       </p>
+      <InlineWidget url={data.bookingUrl} styles={{ height: "630px" }} />
       <a
         href={data.bookingUrl}
         target="_blank"
         rel="noopener noreferrer"
-        className="inline-flex items-center px-4 py-2 rounded-lg bg-[var(--color-background-info-surface)] text-[var(--color-text-info)] text-sm font-medium hover:opacity-80 transition-opacity"
+        className="inline-block mt-3 text-xs text-[var(--color-text-info)] hover:opacity-80 transition-opacity"
       >
-        Book a Meeting
+        Can&apos;t see it? Open in a new tab →
       </a>
     </div>
   );


### PR DESCRIPTION
## Summary
- Replaces the plain "Book a Meeting" link in `AvailabilityCard` with `react-calendly`'s `InlineWidget` (630px), giving users an in-conversation scheduling experience
- Adds a compact fallback link ("Can't see it? Open in a new tab →") below the widget
- Updates sandbox CSP in `app.ts`: adds `frameDomains: ["https://calendly.com"]` and `"https://assets.calendly.com"` to `resourceDomains` so the embed script and iframe can load

## Test Plan
- [ ] All 67 widget tests + 80 server tests pass (`npm test`)
- [ ] Build passes (`npm run build`)
- [ ] Connect to ChatGPT via ngrok and ask for availability — Calendly widget renders inline
- [ ] Fallback link opens Calendly in new tab

Closes #10