### PR TITLE
feat(#15): add show_portfolio tool with inline iframe widget

### DIFF
--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -89,7 +89,7 @@ function createMcpServer() {
                 csp: {
                   connectDomains: ["https://ask-aneeq-server-production.up.railway.app"],
                   resourceDomains: ["https://*.oaistatic.com", "https://assets.calendly.com"],
-                  frameDomains: ["https://calendly.com"],
+                  frameDomains: ["https://calendly.com", "https://aneeqhassan.com"],
                 },
               },
             },

--- a/server/src/tools/index.ts
+++ b/server/src/tools/index.ts
@@ -26,6 +26,10 @@ import {
   handleCompareSkills,
 } from "./compare-skills.js";
 import { askAnythingSchema, handleAskAnything } from "./ask-anything.js";
+import {
+  showPortfolioSchema,
+  handleShowPortfolio,
+} from "./show-portfolio.js";
 
 export function registerTools(server: McpServer) {
   registerAppTool(
@@ -186,5 +190,25 @@ export function registerTools(server: McpServer) {
       },
     },
     handleAskAnything,
+  );
+
+  registerAppTool(
+    server,
+    "show_portfolio",
+    {
+      title: "Show Portfolio",
+      description:
+        "See Aneeq's full portfolio website — embedded inline for a rich visual overview of his work.",
+      inputSchema: showPortfolioSchema,
+      annotations: {
+        readOnlyHint: true,
+        openWorldHint: false,
+        destructiveHint: false,
+      },
+      _meta: {
+        ui: { resourceUri: "ui://widget/aneeq-profile.html" },
+      },
+    },
+    handleShowPortfolio,
   );
 }

--- a/server/src/tools/show-portfolio.test.ts
+++ b/server/src/tools/show-portfolio.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "vitest";
+import { handleShowPortfolio } from "./show-portfolio.js";
+import { aneeqData } from "../data/aneeq-data.js";
+
+describe("show_portfolio tool", () => {
+  it("returns portfolio view in structured content", async () => {
+    const result = await handleShowPortfolio({});
+
+    expect(result.structuredContent.view).toBe("portfolio");
+  });
+
+  it("returns portfolio URL from aneeq data", async () => {
+    const result = await handleShowPortfolio({});
+
+    expect(result.structuredContent.data.url).toBe(aneeqData.contact.portfolio);
+  });
+
+  it("returns text content with portfolio URL", async () => {
+    const result = await handleShowPortfolio({});
+
+    expect(result.content[0].type).toBe("text");
+    expect(result.content[0].text).toContain(aneeqData.contact.portfolio);
+  });
+});

--- a/server/src/tools/show-portfolio.ts
+++ b/server/src/tools/show-portfolio.ts
@@ -1,0 +1,22 @@
+import { aneeqData } from "../data/aneeq-data.js";
+
+export const showPortfolioSchema = {};
+
+export type ShowPortfolioInput = Record<string, never>;
+
+export async function handleShowPortfolio(_input: ShowPortfolioInput) {
+  const url = aneeqData.contact.portfolio;
+
+  return {
+    structuredContent: {
+      view: "portfolio",
+      data: { url },
+    },
+    content: [
+      {
+        type: "text" as const,
+        text: `View Aneeq's portfolio: ${url}`,
+      },
+    ],
+  };
+}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -8,6 +8,7 @@ import { EducationCard } from "./components/EducationCard";
 import { RecommendationsCard } from "./components/RecommendationsCard";
 import { AvailabilityCard } from "./components/AvailabilityCard";
 import { SkillComparisonView } from "./components/SkillComparisonView";
+import { PortfolioView } from "./components/PortfolioView";
 import { HelpCircle } from "lucide-react";
 import { Badge } from "@openai/apps-sdk-ui/components/Badge";
 
@@ -103,6 +104,8 @@ export function App() {
       {view === "availability" && <AvailabilityCard data={data} />}
 
       {view === "skill-comparison" && <SkillComparisonView data={data} />}
+
+      {view === "portfolio" && <PortfolioView data={data} />}
     </div>
   );
 }

--- a/web/src/components/PortfolioView/PortfolioView.test.tsx
+++ b/web/src/components/PortfolioView/PortfolioView.test.tsx
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { PortfolioView } from "./PortfolioView";
+
+const mockData = { url: "https://aneeqhassan.com" };
+
+describe("PortfolioView", () => {
+  it("renders the heading", () => {
+    render(<PortfolioView data={mockData} />);
+    expect(screen.getByText("Aneeq's Portfolio")).toBeInTheDocument();
+  });
+
+  it("renders an iframe with the portfolio URL", () => {
+    render(<PortfolioView data={mockData} />);
+    const iframe = screen.getByTitle("Aneeq Hassan's Portfolio");
+    expect(iframe).toBeInTheDocument();
+    expect(iframe).toHaveAttribute("src", "https://aneeqhassan.com");
+  });
+
+  it("renders a fallback link with correct href", () => {
+    render(<PortfolioView data={mockData} />);
+    const link = screen.getByRole("link", { name: /Open in a new tab/i });
+    expect(link).toHaveAttribute("href", "https://aneeqhassan.com");
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", "noopener noreferrer");
+  });
+});

--- a/web/src/components/PortfolioView/PortfolioView.tsx
+++ b/web/src/components/PortfolioView/PortfolioView.tsx
@@ -1,0 +1,26 @@
+interface Props {
+  data: { url: string };
+}
+
+export function PortfolioView({ data }: Props) {
+  return (
+    <div className="rounded-xl border border-default bg-surface p-5 shadow-sm animate-fade-in">
+      <h2 className="heading-md mb-4">Aneeq&apos;s Portfolio</h2>
+      <iframe
+        src={data.url}
+        title="Aneeq Hassan's Portfolio"
+        className="w-full rounded-lg border border-default"
+        style={{ height: "700px" }}
+        sandbox="allow-scripts allow-same-origin allow-popups"
+      />
+      <a
+        href={data.url}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="inline-block mt-3 text-xs text-[var(--color-text-info)] hover:opacity-80 transition-opacity"
+      >
+        Open in a new tab →
+      </a>
+    </div>
+  );
+}

--- a/web/src/components/PortfolioView/index.ts
+++ b/web/src/components/PortfolioView/index.ts
@@ -1,0 +1,1 @@
+export { PortfolioView } from "./PortfolioView";

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -81,7 +81,8 @@ export type ViewType =
   | "recommendations"
   | "availability"
   | "skill-comparison"
-  | "analytics";
+  | "analytics"
+  | "portfolio";
 
 export interface ToolResultData {
   view: ViewType;


### PR DESCRIPTION
## Summary
- New `show_portfolio` MCP tool that returns the portfolio URL (`aneeqhassan.com`) as structured content with `view: "portfolio"`
- New `PortfolioView` React component rendering the portfolio site in a full-height iframe with fallback link
- CSP `frameDomains` updated to allow `https://aneeqhassan.com`
- `"portfolio"` added to `ViewType` union and wired into `App.tsx` view router

## Test plan
- [x] Tool handler unit tests (3 tests) — verifies view type, URL source, and text content
- [x] PortfolioView component tests (3 tests) — verifies heading, iframe src, and fallback link
- [x] All 153 existing + new tests pass
- [x] Lint and typecheck clean
- [x] Docker build succeeds

Closes #15